### PR TITLE
Allow merged yaml to be returned in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# vNext
+
+- Added a `--merged-yaml` option to allow merged yaml to be returned in response from gitlab API
+
 # v2.2.0
 
 - Add a `--personal-access-token` option specify a personal access token (e.g. when 2FA is enabled). Thanks @fhitche1 (!13)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Global options:
    --timeout value, -t value            timeout in second after which http request to Gitlab API will timeout (and the program will fails) (default: 5) [$GCL_TIMEOUT]
    --no-color, -n                       don't color output. By defaults the output is colorized if a compatible terminal is detected. (default: false) [$GCL_NOCOLOR]
    --verbose, -v                        verbose mode (default: false) [$GCL_VERBOSE]
+   --merged-yaml, -m                    include merged yaml in response (default: false) [$GCL_INCLUDE_MERGED_YAML]
    --help, -h                           show help (default: false)
    --version                            print the version information (default: false)
    

--- a/gitlab.go
+++ b/gitlab.go
@@ -51,9 +51,10 @@ type GitlabAPILintRequest struct {
 
 // GitlabAPILintResponse struct represents the JSON body of a response from the Gitlab API /ci/lint
 type GitlabAPILintResponse struct {
-	Status string   `json:"status,omitempty"`
-	Error  string   `json:"error,omitempty"`
-	Errors []string `json:"errors,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	Error      string   `json:"error,omitempty"`
+	Errors     []string `json:"errors,omitempty"`
+	MergedYaml string   `json:"merged_yaml,omitempty"`
 }
 
 // Search in the given directory a git repository directory
@@ -164,7 +165,7 @@ func lintGitlabCIUsingAPI(rootURL string, ciFileContent string) (status bool, ms
 	reqBody, _ := json.Marshal(reqParams)
 
 	// Prepare requesting the API
-	lintURL := rootURL + gitlabAPICiLintPath
+	lintURL := fmt.Sprintf("%s%s?include_merged_yaml=%t", rootURL, gitlabAPICiLintPath, includeMergedYaml)
 	if verboseMode {
 		fmt.Printf("Querying %s...\n", lintURL)
 	}
@@ -193,6 +194,10 @@ func lintGitlabCIUsingAPI(rootURL string, ciFileContent string) (status bool, ms
 	if err != nil {
 		err = fmt.Errorf("Unable to parse JSON response: %w", err)
 		return
+	}
+
+	if result.MergedYaml != "" {
+		fmt.Printf("Merged yaml: %s\n", result.MergedYaml)
 	}
 
 	// Analyse the results

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ var colorMode = true
 // Tells if verbose mode is on or off
 var verboseMode = false
 
+// Tells if the response should include the merged yaml from the Gitlab API
+var includeMergedYaml = false
+
 // Analyse a PATH argument, that can be a directory or file, to use it as a gitlab-ci file a a directory
 // where to start searching
 func processPathArgument(path string) {
@@ -167,6 +170,13 @@ Usage:
 			Usage:       "verbose mode",
 			EnvVars:     []string{"GCL_VERBOSE"},
 			Destination: &verboseMode,
+		},
+		&cli.BoolFlag{
+			Name:        "merged-yaml",
+			Aliases:     []string{"m"},
+			Usage:       "include merged yaml in response",
+			EnvVars:     []string{"GCL_INCLUDE_MERGED_YAML"},
+			Destination: &includeMergedYaml,
 		},
 	}
 	cli.VersionFlag = &cli.BoolFlag{


### PR DESCRIPTION
gitlab allows for returning the merged yaml in the API response -
this change provides the same feature

See: https://docs.gitlab.com/ee/api/lint.html